### PR TITLE
Over-explain the problem to point people in the right direction.

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,13 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
     debug('[finsihed]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
 
     if (total > 20000) {
-      console.warn('[WARN] `' + relativePath + '` took: ' + total + 'ms (more then 20,000ms)');
+      console.warn(
+        '[WARN] `' + relativePath + '` took: ' + total + 'ms (more then 20,000ms). ' +
+        'This is likely due to the total amount of code that is being minified. You may be ' +
+        'including more than you intended, or re-minifying vendor code that has already been ' +
+        'processed. If you know of files that don\'t need to be minified you can exclude them with' +
+        'the `exclusion` option. See: https://github.com/ef4/broccoli-uglify-sourcemap#usage'
+      );
     }
 
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var symlinkOrCopy = require('symlink-or-copy');
 var mkdirp = require('mkdirp');
 var srcURL = require('source-map-url');
 var MatcherCollection = require('matcher-collection');
+var debug = require('debug')('broccoli-uglify-sourcemap');
 
 module.exports = UglifyWriter;
 
@@ -115,7 +116,18 @@ UglifyWriter.prototype.processFile = function(inFile, outFile, relativePath, out
   }
 
   try {
+    var start = new Date();
+    debug('[starting]: %s %dKB', relativePath, (src.length / 1000));
     var result = UglifyJS.minify(src, merge(opts, this.options));
+    var end = new Date();
+    var total = end - start;
+    debug('[finsihed]: %s %dKB in %dms', relativePath, (result.code.length / 1000), total);
+
+    if (total > 20000) {
+      console.warn('[WARN] `' + relativePath + '` took: ' + total + 'ms (more then 20,000ms)');
+    }
+
+
   } catch(e) {
     e.filename = relativePath;
     throw e;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-writer": "^0.1.1",
+    "debug": "^2.2.0",
     "lodash-node": "^2.4.1",
     "matcher-collection": "^1.0.0",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
In the name of trying to point people in the right direction, it seems like just giving more context for why the process took a long time could go a long way. This may be a little over the top, but it would have helped me when I was debugging a long build-time problem for sure.
